### PR TITLE
Post to amble.quest, too

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,29 @@ async function handleRequest() {
 
   try {
     for (const message of messages) {
-      await fetch("https://tweelay.nyble.dev/yvrships/", {
+      let tweelay_promise = fetch("https://tweelay.nyble.dev/yvrships/", {
         method: "POST",
         headers: {
           "x-api-key": TWEELAY_API_KEY,
         },
         body: message
-      })
+      });
+
+      let feeling_promise = fetch("https://feeling.nyble.dev/amble.quest/cargovan/", {
+        method: "POST",
+        headers: {
+          "x-api-key": TWEELAY_API_KEY,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({
+          'status': message,
+          'visibility': 'unlisted'
+        })
+      });
+
+      await tweelay_promise;
+      await feeling_promise;
+
       console.log("i sent a request! it said " + message);
     }
 

--- a/index.js
+++ b/index.js
@@ -67,9 +67,7 @@ async function handleRequest() {
         })
       });
 
-      await tweelay_promise;
-      await feeling_promise;
-
+      await Promise.allSettled([tweelay_promise, feeling_promise]);
       console.log("i sent a request! it said " + message);
     }
 


### PR DESCRIPTION
This enabled cargo-van to post to [@cargovan@amble.quest](https://amble.quest/cargovan) as well as Twitter. I think it should work? But I honestly don't know. How would I test this?

Anyway, the fedi-relay is systemd start and enabled on my side, so it should work whenever you merge.

It's set to post as `unlisted` because I don't want to fill the federated or local timelines.

<3